### PR TITLE
Compatibility with Shaarli v0.12.0-beta

### DIFF
--- a/favicons/favicons.php
+++ b/favicons/favicons.php
@@ -9,6 +9,17 @@
 use Shaarli\Plugin\PluginManager;
 
 /**
+ * Get plugin assets base path
+ * 
+ * @param array $data - hook data
+ * 
+ * @return string - the basepath of the assets
+ */
+function favicons_get_basepath($data) {
+    return ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
+}
+
+/**
  * Hook render_includes.
  * Executed on every page redering.
  *
@@ -27,7 +38,7 @@ function hook_favicons_render_includes($data)
 {
     // List of plugin's CSS files.
     // Note that you just need to specify CSS path.
-    $data['css_files'][] = PluginManager::$PLUGINS_PATH . '/favicons/favicons.css';
+    $data['css_files'][] = favicons_get_basepath($data) . '/favicons/favicons.css';
     return $data;
 }
 
@@ -52,8 +63,8 @@ function hook_favicons_render_footer($data)
 {
     // List of plugin's JS files.
     // Note that you just need to specify CSS path.
-	$data['js_files'][] = PluginManager::$PLUGINS_PATH . '/favicons/jquery-3.3.1.slim.min.js';
-	$data['js_files'][] = PluginManager::$PLUGINS_PATH . '/favicons/favicons.js';
+	$data['js_files'][] = favicons_get_basepath($data) . '/favicons/jquery-3.3.1.slim.min.js';
+	$data['js_files'][] = favicons_get_basepath($data) . '/favicons/favicons.js';
     return $data;
 }
 


### PR DESCRIPTION
This PR ensures resources are always loading from the right path (subpath Shaarli install or the rewritten URLs in the new Shaarli 0.12.0-beta).

FYI, Shaarli 0.12.0-beta has introduced lots of changes in https://github.com/shaarli/Shaarli/pull/1511 and one was that relative asset URLs are no longer promised to be working on all pages that moved to a subpath.

More info: https://github.com/kalvn/Shaarli-Material/issues/115#issuecomment-687625456